### PR TITLE
CLI: added 'envfile' subcommand to 'gwup stubs ingester' (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,19 @@ with these contents:
 ```
 UPLOADER_APP_lONG_NAME = "test.uploader"
 UPLOADER_APP_INGESTER_LONG_NAME = "test.ingester"
+```
+
+Create a second `.env` at the location returned by: 
+```shell
+gwup stubs ingester envfile
+```
+
+with these contents:
+```
 STUB_INGESTER_APP_lONG_NAME = "test.ingester"
 STUB_INGESTER_APP_UPLOADER_LONG_NAME = "test.uploader"
 ```
+
 
 Create local test certificate authority:
 ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gridworks-uploader"
-version = "1.0.1"
+version = "1.0.2"
 description = "Gridworks Uploader"
 authors = ["Andrew Schweitzer <schweitz72@gmail.com>"]
 license = "MIT"

--- a/src/gwupload/stubs/ingester/ingester_cli.py
+++ b/src/gwupload/stubs/ingester/ingester_cli.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 
+import rich
 import typer
 from gwproactor_test.certs import generate_dummy_certs
 
@@ -58,6 +59,12 @@ def config(
     StubIngesterApp.print_settings(
         env_file=StubIngesterApp.default_env_path() if not env_file else Path(env_file)
     )
+
+
+@app.command()
+def envfile() -> None:
+    """Print the default path to the environment file."""
+    rich.print(StubIngesterApp.default_env_path())
 
 
 @app.callback()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ def test_cli_completes() -> None:
         ["stubs", "ingester", "run", "--dry-run"],
         ["stubs", "ingester", "gen-test-certs", "--dry-run"],
         ["stubs", "ingester", "config"],
+        ["stubs", "ingester", "envfile"],
         ["stubs", "client"],
         ["stubs", "client", "run", "--num-packets", "0"],
         ["service"],


### PR DESCRIPTION
CLI: added 'gwup stubs ingester envfile' command to show the path to the stub ingester env file.